### PR TITLE
Remove React.FunctionalComponent from tutorial components

### DIFF
--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -5,7 +5,7 @@ import toast from "react-hot-toast";
 
 interface AuthButtonProps extends ButtonProps {}
 
-const AuthButton: React.FunctionComponent<AuthButtonProps> = (props) => {
+const AuthButton = (props: AuthButtonProps) => {
   const [connectQuery, connect] = useConnect();
   const [accountQuery] = useAccount();
 

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -9,7 +9,7 @@ interface CommentProps {
   comment: Comment;
 }
 
-const Comment: React.FunctionComponent<CommentProps> = ({ comment }) => {
+const Comment = ({ comment }: CommentProps) => {
   return (
     <HStack spacing={3} alignItems="start">
       <Avatar size={48} address={comment.creator_address} />

--- a/components/CommentEditor.tsx
+++ b/components/CommentEditor.tsx
@@ -10,9 +10,7 @@ interface CommentEditorProps {
   topic: string;
 }
 
-const CommentEditor: React.FunctionComponent<CommentEditorProps> = ({
-  topic,
-}) => {
+const CommentEditor = ({ topic }: CommentEditorProps) => {
   const [message, setMessage] = React.useState("");
   const mutation = useAddComment();
   const [accountQuery] = useAccount();

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -9,7 +9,7 @@ interface CommentsProps {
   topic: string;
 }
 
-const Comments: React.FunctionComponent<CommentsProps> = ({ topic }) => {
+const Comments = ({ topic }: CommentsProps) => {
   const query = useComments({ topic });
 
   useEvents({ topic });

--- a/components/Username.tsx
+++ b/components/Username.tsx
@@ -7,10 +7,10 @@ interface UsernameProps extends TextProps {
   address: string;
 }
 
-const Username: React.FunctionComponent<UsernameProps> = ({
+const Username = ({
   address,
   ...otherProps
-}) => {
+}: UsernameProps) => {
   const [query] = useEnsLookup({ address });
 
   // Show ens name if exists, but show truncated address as fallback


### PR DESCRIPTION
General consensus today is that React.FunctionComponent (or the shorthand React.FC) is discouraged.

More info:
https://github.com/facebook/create-react-app/pull/8177
https://github.com/typescript-cheatsheets/react
https://medium.com/raccoons-group/why-you-probably-shouldnt-use-react-fc-to-type-your-react-components-37ca1243dd13